### PR TITLE
Added pickling support to the Robot class

### DIFF
--- a/source/romocc/Robot.cpp
+++ b/source/romocc/Robot.cpp
@@ -55,6 +55,11 @@ RobotState::pointer Robot::getCurrentState() const
     return mCurrentState;
 }
 
+connectionConfiguration Robot::getCommuncationConfiguration() const
+{
+    return mCommunicationInterface->getConnectionConfig();
+}
+
 void Robot::runMotionQueue(MotionQueue queue)
 {
     mMotionQueue = std::move(queue);

--- a/source/romocc/Robot.h
+++ b/source/romocc/Robot.h
@@ -28,6 +28,8 @@ class ROMOCC_EXPORT Robot : public Object
         void shutdown();
 
         RobotState::pointer getCurrentState() const;
+        connectionConfiguration getCommuncationConfiguration() const;
+
         void addUpdateSubscription(std::function<void()> updateFunction);
 
         template <class Target>

--- a/source/romocc/communication/CommunicationInterface.cpp
+++ b/source/romocc/communication/CommunicationInterface.cpp
@@ -100,6 +100,11 @@ void CommunicationInterface::setManipulator(romocc::Manipulator manipulator)
     mCurrentState->setManipulator(manipulator);
 }
 
+connectionConfiguration CommunicationInterface::getConnectionConfig()
+{
+    return connectionConfiguration{ mHost, mPort };
+}
+
 RobotState::pointer CommunicationInterface::getRobotState()
 {
     return mCurrentState;

--- a/source/romocc/communication/CommunicationInterface.h
+++ b/source/romocc/communication/CommunicationInterface.h
@@ -13,6 +13,11 @@
 
 namespace romocc
 {
+struct connectionConfiguration
+{
+    std::string host;
+    int port;
+};
 
 class ROMOCC_EXPORT CommunicationInterface : public Object
 {
@@ -24,6 +29,7 @@ class ROMOCC_EXPORT CommunicationInterface : public Object
 
         void configConnection(std::string host, int port);
         void setManipulator(Manipulator manipulator);
+        connectionConfiguration getConnectionConfig();
 
         RobotState::pointer getRobotState();
 

--- a/source/romocc/robotics/RobotState.cpp
+++ b/source/romocc/robotics/RobotState.cpp
@@ -246,4 +246,9 @@ Transform3d RobotState::jointConfigToOperationalConfig(romocc::Vector6d jointCon
     return transform_to_joint(jointConfig);
 }
 
+Manipulator RobotState::getManipulator()
+{
+    return mManipulator;
+}
+
 }

--- a/source/romocc/robotics/RobotState.h
+++ b/source/romocc/robotics/RobotState.h
@@ -52,6 +52,8 @@ class ROMOCC_EXPORT RobotState : public Object
         Vector6d operationalConfigToJointConfig(Transform3d transform);
         Transform3d jointConfigToOperationalConfig(Vector6d jointConfig);
 
+        Manipulator getManipulator();
+
         std::shared_ptr<FKSolver> getFKSolver();
         std::shared_ptr<IKSolver> getIKSolver();
 


### PR DESCRIPTION
Added pickling support to the Robot class. For that, getters had to be made as described below.

RobotState:
- Made getter for mManipulator, named getManipulator (used when pickling the Robot object)

CommunicationInterface
- Made getter for getConfiguration
- Made struct connectionConfiguration to hold the "host" and "ip". Used by getConfiguration (used when pickling the Robot object, through Robot::getCommunicationConfiguration)

Robot
- Made getCommunicationConfiguration to get connectionConfiguration from the CommunicationInterface object

pyromocc
- Added pickling support: when pickling a Robot object, if open, the connection with the robot is closed (joining the communication thread), so the new unpickled object can resume it.
- The new object is returned as a std::unique_ptr instead of a shared_ptr
- Exposed Robot::getCommunicationConfiguration